### PR TITLE
Replaced argparse with click for constructing the CLI interface.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
           ],
       },
     install_requires=[
-            'PyYAML>=3.11'
+            'PyYAML>=3.11',
+            'click>=6.6',
         ]
 )

--- a/skipper/commands.py
+++ b/skipper/commands.py
@@ -1,20 +1,47 @@
 import grp
 import logging
 import os
-import re
-import yaml
+import click
 from skipper import docker
 from skipper import git
 
 
-def build(registry, image, dockerfile, tag=None):
+@click.group()
+@click.option('-q', '--quiet', help='Silence the output', is_flag=True, default=False)
+def cli(quiet):
+    '''
+    Easily dockerize your Git repository
+    '''
+
+    logging_level = logging.INFO if quiet else logging.DEBUG
+    logging.basicConfig(format='%(message)s', level=logging_level)
+
+
+@cli.command()
+@click.option('--registry', help='URL of the docker registry')
+@click.option('--image', help='Image to build')
+@click.option('--tag', help='Tag of the image')
+def build(registry, image, tag=None):
+    '''
+    Builds a containers
+    '''
+    dockerfile = image + '.Dockerfile'
     workspace = os.getcwd()
     tag = tag or git.get_hash()
     fqdn_image = _generate_fqdn_image(registry, image, tag)
     docker.build(workspace, dockerfile, fqdn_image)
 
 
+@cli.command(context_settings=dict(ignore_unknown_options=True))
+@click.option('--registry', help='URL of the docker registry')
+@click.option('--image', help='Image to build')
+@click.option('--tag', help='Tag of the image')
+@click.option('-e', '--env', multiple=True, help='Environment variables to pass the container')
+@click.argument('command', nargs=-1, type=click.UNPROCESSED)
 def run(registry, image, tag, env, command):
+    '''
+    Runs commands inside a container
+    '''
     fqdn_image = _generate_fqdn_image(registry, image, tag)
 
     cwd = os.getcwd()
@@ -27,54 +54,32 @@ def run(registry, image, tag, env, command):
     if len(command) == 0:
         logging.error('Command was not provided')
     else:
-        return docker.run(workspace, project, uid, gid, fqdn_image, env, command)
+        return docker.run(workspace, project, uid, gid, fqdn_image, list(env), list(command))
 
 
+@cli.command(context_settings=dict(ignore_unknown_options=True))
+@click.option('--registry', help='URL of the docker registry')
+@click.option('--image', help='Image to build')
+@click.option('--tag', help='Tag of the image')
+@click.option('-e', '--env', multiple=True, help='Environment variables to pass the container')
+@click.argument('makefile')
+@click.argument('target')
 def make(registry, image, tag, env, makefile, target):
+    '''
+    Executes makefile target
+    '''
     command = ['make', '-f', makefile, target]
-    run(registry, image, tag, env, command)
+    fqdn_image = _generate_fqdn_image(registry, image, tag)
 
+    cwd = os.getcwd()
+    workspace = os.path.dirname(cwd)
+    project = os.path.basename(cwd)
 
-def depscheck(registry, image, tag, manifesto_path):
-    installed_pips = _get_installed_pips(registry, image, tag)
-    official_pips = _get_official_pips(manifesto_path)
-    _compare_pips(installed_pips, official_pips)
+    uid = os.getuid()
+    gid = grp.getgrnam('docker').gr_gid
+
+    return docker.run(workspace, project, uid, gid, fqdn_image, list(env), list(command))
 
 
 def _generate_fqdn_image(registry, image, tag='latest'):
     return registry + '/' + image + ':' + tag
-
-
-def _get_installed_pips(registry, image, tag):
-    command = ['pip', 'freeze', '--disable-pip-version-check']
-    output = run(registry, image, tag, None, command)
-    installed_pips = {}
-    for line in output:
-        if len(line) > 0:
-            pip, version = re.match(r'([^=]+)===?([^=]+)', line).groups()
-        installed_pips[pip] = version
-
-    return installed_pips
-
-
-def _get_official_pips(manifesto_path):
-    with open(manifesto_path) as manifesto_file:
-        manifesto = yaml.load(manifesto_file)
-
-    official_pips = {}
-    for req in manifesto['requirements']:
-        if req.get('pips') is not None:
-            official_pips.update({pip_name: req.get('revision') for pip_name in req.get('pips')})
-
-    return official_pips
-
-
-def _compare_pips(installed_pips, official_pips):
-    for installed_pip, installed_version in installed_pips.iteritems():
-        official_version = official_pips.get(installed_pip)
-        # TODO: remove this check once we support version check of non-strato packages
-        if official_version is None:
-            continue
-        if installed_version != official_version:
-            logging.error('Version mismatch for package %(pip)s: %(installed_version)s != %(official_version)s',
-                          dict(pip=installed_pip, installed_version=installed_version, official_version=official_version))

--- a/skipper/main.py
+++ b/skipper/main.py
@@ -1,73 +1,7 @@
-import argparse
-import logging
-import os
-import yaml
 from skipper import commands
 
 
-DEFAULT_REGISTRY = 'rackattack-nas.dc1:5000'
-DEFAULT_TAG = 'latest'
-DEFAULT_CONFIG_FILE = 'skipper.yaml'
-
-
-def load_config():
-    config = {}
-    if os.path.exists(DEFAULT_CONFIG_FILE):
-        config = yaml.load(open(DEFAULT_CONFIG_FILE))
-
-    return config
-
-
-def parse_args(config):
-    parser = argparse.ArgumentParser(prog='skipper',
-                                     description='Easily dockerize your Git repository',
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-
-    parser.add_argument('--registry', default=DEFAULT_REGISTRY, help='url of the docker registry')
-    parser.add_argument('--image', default=config.get('build-container'), help='image to use for running commands')
-    parser.add_argument('--tag', default=DEFAULT_TAG, help='tag of the image to use')
-    parser.add_argument('-e', '--env', action='append', help='set environment variables')
-    parser.add_argument('-q', '--quiet', action='store_true', help='silence output')
-
-    subparsers = parser.add_subparsers(dest='subparser_name')
-
-    parser_build = subparsers.add_parser('build', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_build.add_argument('--image', required=True, help='image name')
-    parser_build.add_argument('--tag', default=DEFAULT_TAG, help='image tag')
-
-    parser_run = subparsers.add_parser('run', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_run.add_argument('command', nargs=argparse.REMAINDER)
-
-    parser_make = subparsers.add_parser('make', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_make.add_argument('-f', '--file', default=config.get('makefile', 'Makefile'), help='path to the makefile')
-    parser_make.add_argument('target', nargs=argparse.REMAINDER)
-
-    parser_make = subparsers.add_parser('depscheck', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser_make.add_argument('-f', '--file', help='path to the manifesto')
-
-    return parser.parse_args()
-
-
-def main():
-    config = load_config()
-    args = parse_args(config)
-
-    logging_level = logging.INFO if args.quiet else logging.DEBUG
-    logging.basicConfig(format='%(message)s', level=logging_level)
-
-    if args.subparser_name == 'run':
-        commands.run(args.registry, args.image, args.tag, args.env, args.command)
-
-    elif args.subparser_name == 'build':
-        dockerfile = args.image + '.Dockerfile'
-        commands.build(args.registry, args.image, dockerfile, args.tag)
-
-    elif args.subparser_name == 'make':
-        commands.make(args.registry, args.image, args.tag, args.env, args.file, args.target[0])
-
-    elif args.subparser_name == 'depscheck':
-        commands.depscheck(args.registry, args.image, args.tag, args.file)
-
-
 if __name__ == '__main__':
-    main()
+    # pylint: disable=unexpected-keyword-arg
+    # pylint: disable=no-value-for-parameter
+    commands.cli(prog_name='skipper')

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27
 
 [testenv]
 deps = 
+    click
     mock
     pep8
     pylint


### PR DESCRIPTION
Click allows us to create a CLI command by wrapping the function that
implements the command logic with decorators. This way the code is more
testable and self documented.
Also removed depscheck command, because it is not belong here.

@rom-stratoscale @eran-stratoscale please review.
