### PR TITLE
Bug Fix: images command didn't handle correctly multiple local images.

### DIFF
--- a/skipper/utils.py
+++ b/skipper/utils.py
@@ -42,8 +42,8 @@ def get_local_images_info(images, registry=None):
         output = subprocess.check_output(command + [name])
         if output == '':
             continue
-        info = json.loads(output)
-        images_info += [['LOCAL', info['name'], info['tag']]]
+        image_info = [json.loads(record) for record in output.splitlines()]
+        images_info += [['LOCAL', info['name'], info['tag']] for info in image_info]
 
     return images_info
 


### PR DESCRIPTION
When multiple local images exits 

When multiple local tags exits for the same image, 'docker images'
returns one line per tag, where each line is a separate json string
(i.e. {"name": image_name, "tag: image_tag}). This means that each line
should be decoded as a json separately.