### PR TITLE
Don't allow wheel distribution.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 import os
+import sys
 from setuptools import find_packages
 from distutils.core import setup
 
+# Workaround: bdist_wheel doesn't support absolute paths in data_files
+# (see: https://bitbucket.org/pypa/wheel/issues/92). 
+if os.getuid() == 0 and 'bdist_wheel' in sys.argv:
+    raise RuntimeError("This setup.py does not support wheels")
 
 setup(
     setup_requires = [


### PR DESCRIPTION
Wheel distribution doesn't support absolute paths for data_files (see:
https://bitbucket.org/pypa/wheel/issues/92)

@rom-stratoscale @eran-stratoscale this should allow proper installation via `pip install strato-skipper` (without the need to specify `--no-cache-dir`)