### PR TITLE
Use user_id when adding user to container

### DIFF
--- a/data/skipper-entrypoint.sh
+++ b/data/skipper-entrypoint.sh
@@ -2,7 +2,7 @@
 
 getent passwd ${SKIPPER_USERNAME} > /dev/null
 if [ x"$?" != x"0" ]; then
-	useradd -M "${SKIPPER_USERNAME}"
+	useradd -u ${SKIPPER_UID} --non-unique -M "${SKIPPER_USERNAME}"
 fi
 
 groupadd -g ${SKIPPER_DOCKER_GID} docker

--- a/skipper/runner.py
+++ b/skipper/runner.py
@@ -1,4 +1,5 @@
 import grp
+import getpass
 import logging
 import os
 import subprocess
@@ -36,8 +37,10 @@ def _run_nested(fqdn_image, environment, command, interactive):
     for env in environment:
         docker_cmd += ['-e', env]
 
-    user = os.environ.get('USER', 'skipper')
+    user = getpass.getuser()
+    user_id = os.getuid()
     docker_cmd += ['-e', 'SKIPPER_USERNAME=%(user)s' % dict(user=user)]
+    docker_cmd += ['-e', 'SKIPPER_UID=%(user_id)s' % dict(user_id=user_id)]
 
     docker_gid = grp.getgrnam('docker').gr_gid
     docker_cmd += ['-e', 'SKIPPER_DOCKER_GID=%(docker_gid)s' % dict(docker_gid=docker_gid)]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -37,14 +37,16 @@ class TestRunner(unittest.TestCase):
         runner.run(command)
         popen_mock.assert_called_once_with(command)
 
-    @mock.patch('os.environ.get', autospec=True, return_value='testuser')
+    @mock.patch('getpass.getuser', autospec=True, return_value='testuser')
     @mock.patch('os.getcwd', autospec=True, return_value=PROJECT_DIR)
+    @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_simple_command_nested(self, popen_mock, grp_getgrnam_mock, *args):
+    def test_run_simple_command_nested(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
+        os_getuid_mock.return_value = USER_ID
         command = ['pwd']
         runner.run(command, FQDN_IMAGE)
         expected_nested_command = [
@@ -53,6 +55,7 @@ class TestRunner(unittest.TestCase):
             '--rm',
             '--net', 'host',
             '-e', 'SKIPPER_USERNAME=testuser',
+            '-e', 'SKIPPER_UID=%(user_uid)s' % dict(user_uid=USER_ID),
             '-e', 'SKIPPER_DOCKER_GID=978',
             '-v', '%(workdir)s:%(workdir)s:rw,Z' % dict(workdir=WORKDIR),
             '-v', '/var/lib/osmosis:/var/lib/osmosis:rw,Z',
@@ -65,14 +68,16 @@ class TestRunner(unittest.TestCase):
         ]
         popen_mock.assert_called_once_with(expected_nested_command)
 
-    @mock.patch('os.environ.get', autospec=True, return_value='testuser')
+    @mock.patch('getpass.getuser', autospec=True, return_value='testuser')
     @mock.patch('os.getcwd', autospec=True, return_value=PROJECT_DIR)
+    @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_simple_command_nested_with_env(self, popen_mock, grp_getgrnam_mock, *args):
+    def test_run_simple_command_nested_with_env(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
+        os_getuid_mock.return_value = USER_ID
         command = ['pwd']
         runner.run(command, FQDN_IMAGE, ENV)
         expected_docker_command = [
@@ -83,6 +88,7 @@ class TestRunner(unittest.TestCase):
             '-e', 'KEY1=VAL1',
             '-e', 'KEY2=VAL2',
             '-e', 'SKIPPER_USERNAME=testuser',
+            '-e', 'SKIPPER_UID=%(user_uid)s' % dict(user_uid=USER_ID),
             '-e', 'SKIPPER_DOCKER_GID=978',
             '-v', '%(workdir)s:%(workdir)s:rw,Z' % dict(workdir=WORKDIR),
             '-v', '/var/lib/osmosis:/var/lib/osmosis:rw,Z',
@@ -95,14 +101,16 @@ class TestRunner(unittest.TestCase):
         ]
         popen_mock.assert_called_once_with(expected_docker_command)
 
-    @mock.patch('os.environ.get', autospec=True, return_value='testuser')
+    @mock.patch('getpass.getuser', autospec=True, return_value='testuser')
     @mock.patch('os.getcwd', autospec=True, return_value=PROJECT_DIR)
+    @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_simple_command_nested_interactive(self, popen_mock, grp_getgrnam_mock, *args):
+    def test_run_simple_command_nested_interactive(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
+        os_getuid_mock.return_value = USER_ID
         command = ['pwd']
         runner.run(command, FQDN_IMAGE, interactive=True)
         expected_nested_command = [
@@ -112,6 +120,7 @@ class TestRunner(unittest.TestCase):
             '--rm',
             '--net', 'host',
             '-e', 'SKIPPER_USERNAME=testuser',
+            '-e', 'SKIPPER_UID=%(user_uid)s' % dict(user_uid=USER_ID),
             '-e', 'SKIPPER_DOCKER_GID=978',
             '-v', '%(workdir)s:%(workdir)s:rw,Z' % dict(workdir=WORKDIR),
             '-v', '/var/lib/osmosis:/var/lib/osmosis:rw,Z',
@@ -124,14 +133,16 @@ class TestRunner(unittest.TestCase):
         ]
         popen_mock.assert_called_once_with(expected_nested_command)
 
-    @mock.patch('os.environ.get', autospec=True, return_value='testuser')
+    @mock.patch('getpass.getuser', autospec=True, return_value='testuser')
     @mock.patch('os.getcwd', autospec=True, return_value=PROJECT_DIR)
+    @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True,)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_complex_command_nested(self, popen_mock, grp_getgrnam_mock, *args):
+    def test_run_complex_command_nested(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
+        os_getuid_mock.return_value = USER_ID
         command = ['ls', '-l']
         runner.run(command, FQDN_IMAGE)
         expected_nested_command = [
@@ -140,6 +151,7 @@ class TestRunner(unittest.TestCase):
             '--rm',
             '--net', 'host',
             '-e', 'SKIPPER_USERNAME=testuser',
+            '-e', 'SKIPPER_UID=%(user_uid)s' % dict(user_uid=USER_ID),
             '-e', 'SKIPPER_DOCKER_GID=978',
             '-v', '%(workdir)s:%(workdir)s:rw,Z' % dict(workdir=WORKDIR),
             '-v', '/var/lib/osmosis:/var/lib/osmosis:rw,Z',
@@ -152,14 +164,16 @@ class TestRunner(unittest.TestCase):
         ]
         popen_mock.assert_called_once_with(expected_nested_command)
 
-    @mock.patch('os.environ.get', autospec=True, return_value='testuser')
+    @mock.patch('getpass.getuser', autospec=True, return_value='testuser')
     @mock.patch('os.getcwd', autospec=True, return_value=PROJECT_DIR)
+    @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_complex_command_nested_with_env(self, popen_mock, grp_getgrnam_mock, *args):
+    def test_run_complex_command_nested_with_env(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
+        os_getuid_mock.return_value = USER_ID
         command = ['ls', '-l']
         runner.run(command, FQDN_IMAGE, ENV)
         expected_nested_command = [
@@ -170,6 +184,7 @@ class TestRunner(unittest.TestCase):
             '-e', 'KEY1=VAL1',
             '-e', 'KEY2=VAL2',
             '-e', 'SKIPPER_USERNAME=testuser',
+            '-e', 'SKIPPER_UID=%(user_uid)s' % dict(user_uid=USER_ID),
             '-e', 'SKIPPER_DOCKER_GID=978',
             '-v', '%(workdir)s:%(workdir)s:rw,Z' % dict(workdir=WORKDIR),
             '-v', '/var/lib/osmosis:/var/lib/osmosis:rw,Z',


### PR DESCRIPTION
This is required for cases where the build container already has a user
with the same id as the user_id which may cause permission problem.