### PR TITLE
Don't tag images with the registry by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Skipper can serve as your primary tool for your daily development tasks:
 * Use `skipper rmi` to delete your images.
 * Use `skipper make` to execute makefile targets inside a container.
 * Use `skipper run` to run arbitrary commands inside a container.
+* Use `skipper shell` to get an interactive shell inside a container.
 
 ### Global Options
 ```bash
@@ -36,7 +37,6 @@ Skipper can serve as your primary tool for your daily development tasks:
   --build-container-tag         Tag of the build container
   --help                        Show this message and exit.
 ```
-Note that registry is mandatory parameter, as it is used to indentify the images.
 
 ### Build
 Skipper infers the docker images from the Dockerfiles in the top directory of your repository. For example, assuming that there are 2 Dockerfile in the top directory of the repository:
@@ -47,22 +47,22 @@ Dockerfile.development
 
 To build the image that corresponeds to `Dockerfile.production`, run:
 ```bash
-skipper --registry some-registry build production
+skipper build production
 ```
 
 In the same way you can build the image corresponded to `Dockerfile.development`:
 ```bash
-skipper --registry some-registry build development
+skipper build development
 ```
 
 You can also build mutliple images with single command:
 ```bash
-skipper --registry some-registry build development production
+skipper build development production
 ```
 
 If no image is specifed skipper will build all detected images:
 ```bash
-skipper --registry some-registry build
+skipper build
 ```
 
 ### Push
@@ -74,9 +74,9 @@ skipper --registry some-registry push production
 Note that the registry in this command must be the same registry used while building the image.
 
 ### Images
-To list images of your repository, run:
+To list local images of your repository, run:
 ```bash
-skipper --registry some-registry images
+skipper images
 ```
 
 In order to also list also images that were pushed to the registry, run:
@@ -87,7 +87,7 @@ skipper --registry some-registry images -r
 ### Rmi
 To delete an image of your repository, run:
 ```bash
-skipper --registry some-registry rmi production <tag>
+skipper rmi production <tag>
 ```
 
 In order to delete the image from the registry, run:

--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -109,13 +109,13 @@ def images(ctx, remote):
     List images
     '''
     utils.logger.debug("Executing images command")
-    _validate_global_params(ctx, 'registry')
     images_names = utils.get_images_from_dockerfiles()
-    images_info = utils.get_local_images_info(images_names, ctx.obj['registry'])
+    images_info = utils.get_local_images_info(images_names)
     if remote:
+        _validate_global_params(ctx, 'registry')
         images_info += utils.get_remote_images_info(images_names, ctx.obj['registry'])
 
-    print(tabulate.tabulate(images_info, headers=['ORIGIN', 'IMAGE', 'TAG'], tablefmt='grid'))
+    print(tabulate.tabulate(images_info, headers=['REGISTRY', 'IMAGE', 'TAG'], tablefmt='grid'))
 
 
 @cli.command()
@@ -128,12 +128,12 @@ def rmi(ctx, remote, image, tag):
     Delete an image from local docker or from registry
     '''
     utils.logger.debug("Executing rmi command")
-    _validate_global_params(ctx, 'registry')
     _validate_project_image(image)
     if remote:
+        _validate_global_params(ctx, 'registry')
         utils.delete_image_from_registry(ctx.obj['registry'], image, tag)
     else:
-        utils.delete_local_image(ctx.obj['registry'], image, tag)
+        utils.delete_local_image(image, tag)
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))

--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -72,15 +72,33 @@ def push(ctx, image):
     utils.logger.debug("Executing push command")
     _validate_global_params(ctx, 'registry')
     tag = git.get_hash()
+    image_name = image + ':' + tag
     fqdn_image = utils.generate_fqdn_image(ctx.obj['registry'], image, tag)
 
+    utils.logger.debug("Adding tag %(tag)s", dict(tag=fqdn_image))
+    command = [
+        'docker',
+        'tag',
+        image_name,
+        fqdn_image
+    ]
+    runner.run(command)
+
+    utils.logger.debug("Pushing to registry %(registry)s", dict(registry=ctx.obj['registry']))
     command = [
         'docker',
         'push',
         fqdn_image
     ]
+    runner.run(command)
 
-    return runner.run(command)
+    utils.logger.debug("Removing tag %(tag)s", dict(tag=fqdn_image))
+    command = [
+        'docker',
+        'rmi',
+        fqdn_image
+    ]
+    runner.run(command)
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,40 +205,40 @@ class TestCLI(unittest.TestCase):
         ]
         skipper_runner_run_mock.assert_called_once_with(expected_command)
 
-    @mock.patch('skipper.git.get_hash', autospec=True, return_value=TAG)
+    @mock.patch('skipper.git.get_hash', autospec=True, return_value='1234567')
     @mock.patch('skipper.runner.run', autospec=True)
     def test_push(self, skipper_runner_run_mock, *args):
-        push_params = [IMAGE]
+        push_params = ['my_image']
         self._invoke_cli(
             global_params=self.global_params,
             subcmd='push',
             subcmd_params=push_params
         )
-        expected_command = [
-            'docker',
-            'push',
-            FQDN_IMAGE
+        expected_commands = [
+            mock.call(['docker', 'tag', 'my_image:1234567', 'registry.io:5000/my_image:1234567']),
+            mock.call(['docker', 'push', 'registry.io:5000/my_image:1234567']),
+            mock.call(['docker', 'rmi', 'registry.io:5000/my_image:1234567']),
         ]
-        skipper_runner_run_mock.assert_called_once_with(expected_command)
+        skipper_runner_run_mock.assert_has_calls(expected_commands)
 
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('os.path.exists', autospec=True, return_value=True)
     @mock.patch('yaml.load', autospec=True, return_value=SKIPPER_CONF)
-    @mock.patch('skipper.git.get_hash', autospec=True, return_value=TAG)
+    @mock.patch('skipper.git.get_hash', autospec=True, return_value='1234567')
     @mock.patch('skipper.runner.run', autospec=True)
     def test_push_with_defaults_from_config_file(self, skipper_runner_run_mock, *args):
-        push_params = [IMAGE]
+        push_params = ['my_image']
         self._invoke_cli(
             defaults=config.load_defaults(),
             subcmd='push',
             subcmd_params=push_params
         )
-        expected_command = [
-            'docker',
-            'push',
-            FQDN_IMAGE
+        expected_commands = [
+            mock.call(['docker', 'tag', 'my_image:1234567', 'registry.io:5000/my_image:1234567']),
+            mock.call(['docker', 'push', 'registry.io:5000/my_image:1234567']),
+            mock.call(['docker', 'rmi', 'registry.io:5000/my_image:1234567']),
         ]
-        skipper_runner_run_mock.assert_called_once_with(expected_command)
+        skipper_runner_run_mock.assert_has_calls(expected_commands)
 
     @mock.patch('glob.glob', autospec=True, return_value=['Dockerfile.' + IMAGE])
     @mock.patch('tabulate.tabulate', autospec=True)


### PR DESCRIPTION
Instead, add a tag with the registry only when pushing to remote registry, and remove it right afterwards.

@eran-stratoscale @rom-stratoscale please review.