### PR TITLE
Added interactive flag to `skipper make` and `skipper run`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Skipper can serve as your primary tool for your daily development tasks:
 * Use `skipper rmi` to delete your images.
 * Use `skipper make` to execute makefile targets inside a container.
 * Use `skipper run` to run arbitrary commands inside a container.
+* Use `skipper shell` to get an interactive shell inside a container.
 
 ### Global Options
 ```bash
@@ -36,7 +37,6 @@ Skipper can serve as your primary tool for your daily development tasks:
   --build-container-tag         Tag of the build container
   --help                        Show this message and exit.
 ```
-Note that registry is mandatory parameter, as it is used to indentify the images.
 
 ### Build
 Skipper infers the docker images from the Dockerfiles in the top directory of your repository. For example, assuming that there are 2 Dockerfile in the top directory of the repository:
@@ -47,22 +47,22 @@ Dockerfile.development
 
 To build the image that corresponeds to `Dockerfile.production`, run:
 ```bash
-skipper --registry some-registry build production
+skipper build production
 ```
 
 In the same way you can build the image corresponded to `Dockerfile.development`:
 ```bash
-skipper --registry some-registry build development
+skipper build development
 ```
 
 You can also build mutliple images with single command:
 ```bash
-skipper --registry some-registry build development production
+skipper build development production
 ```
 
 If no image is specifed skipper will build all detected images:
 ```bash
-skipper --registry some-registry build
+skipper build
 ```
 
 ### Push
@@ -74,9 +74,9 @@ skipper --registry some-registry push production
 Note that the registry in this command must be the same registry used while building the image.
 
 ### Images
-To list images of your repository, run:
+To list local images of your repository, run:
 ```bash
-skipper --registry some-registry images
+skipper images
 ```
 
 In order to also list also images that were pushed to the registry, run:
@@ -87,7 +87,7 @@ skipper --registry some-registry images -r
 ### Rmi
 To delete an image of your repository, run:
 ```bash
-skipper --registry some-registry rmi production <tag>
+skipper rmi production <tag>
 ```
 
 In order to delete the image from the registry, run:

--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -136,10 +136,11 @@ def rmi(ctx, remote, image, tag):
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
+@click.option('--interactive/--no-interactive', help='Interactive mode', default=True)
 @click.option('-e', '--env', multiple=True, help='Environment variables to pass the container')
 @click.argument('command', nargs=-1, type=click.UNPROCESSED, required=True)
 @click.pass_context
-def run(ctx, env, command):
+def run(ctx, interactive, env, command):
     '''
     Run arbitrary commands
     '''
@@ -148,15 +149,16 @@ def run(ctx, env, command):
     build_container = _prepare_build_container(ctx.obj['registry'],
                                                ctx.obj['build_container_image'],
                                                ctx.obj['build_container_tag'])
-    return runner.run(list(command), fqdn_image=build_container, environment=_expend_env(ctx, env))
+    return runner.run(list(command), fqdn_image=build_container, environment=_expend_env(ctx, env), interactive=interactive)
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
+@click.option('--interactive/--no-interactive', help='Interactive mode', default=True)
 @click.option('-e', '--env', multiple=True, help='Environment variables to pass the container')
 @click.option('-f', 'makefile', help='Makefile to use', default='Makefile')
 @click.argument('target')
 @click.pass_context
-def make(ctx, env, makefile, target):
+def make(ctx, interactive, env, makefile, target):
     '''
     Execute makefile target
     '''
@@ -170,7 +172,7 @@ def make(ctx, env, makefile, target):
         '-f', makefile,
         target
     ]
-    return runner.run(command, fqdn_image=build_container, environment=_expend_env(ctx, env))
+    return runner.run(command, fqdn_image=build_container, environment=_expend_env(ctx, env), interactive=interactive)
 
 
 @cli.command()

--- a/skipper/utils.py
+++ b/skipper/utils.py
@@ -30,6 +30,26 @@ def get_images_from_dockerfiles():
     return images
 
 
+def local_image_exist(image, tag):
+    name = image + ':' + tag
+    command = [
+        'docker',
+        'images',
+        '--format', '{{.ID}}',
+        name
+    ]
+    output = subprocess.check_output(command)
+    return output != ''
+
+
+def remote_image_exist(registry, image, tag):
+    requests.packages.urllib3.disable_warnings()
+    url = 'https://%(registry)s/v2/%(image)s/tags/list' % dict(registry=registry, image=image)
+    response = requests.get(url=url, verify=False)
+    info = response.json()
+    return tag in info['tags']
+
+
 def get_local_images_info(images):
     command = [
         'docker',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -427,7 +427,7 @@ class TestCLI(unittest.TestCase):
             subcmd_params=run_params
         )
         expected_image_name = 'build-container-image:build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_image_name, environment=[])
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_image_name, environment=[], interactive=True)
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('requests.get', autospec=True)
@@ -449,7 +449,7 @@ class TestCLI(unittest.TestCase):
             subcmd_params=run_params
         )
         expected_image_name = 'registry.io:5000/build-container-image:build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_image_name, environment=[])
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_image_name, environment=[], interactive=True)
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('requests.get', autospec=True)
@@ -486,7 +486,7 @@ class TestCLI(unittest.TestCase):
             subcmd_params=run_params
         )
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[])
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[], interactive=True)
 
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('os.path.exists', autospec=True, return_value=True)
@@ -504,7 +504,7 @@ class TestCLI(unittest.TestCase):
         )
         env = ["%s=%s" % (key, value) for key, value in CONFIG_ENV_EVALUATION.iteritems()]
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=env)
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=env, interactive=True)
 
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('os.path.exists', autospec=True, return_value=True)
@@ -522,7 +522,7 @@ class TestCLI(unittest.TestCase):
         )
         env = ["%s=%s" % (key, value) for key, value in CONFIG_ENV_EVALUATION.iteritems()] + ENV
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=env)
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=env, interactive=True)
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -536,7 +536,20 @@ class TestCLI(unittest.TestCase):
             subcmd_params=run_params
         )
         expected_fqdn_image = 'build-container-image:build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=ENV)
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=ENV, interactive=True)
+
+    @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
+    @mock.patch('skipper.runner.run', autospec=True)
+    def test_run_non_interactive(self, skipper_runner_run_mock, *args):
+        command = ['ls', '-l']
+        run_params = ['--no-interactive'] + command
+        self._invoke_cli(
+            global_params=self.global_params,
+            subcmd='run',
+            subcmd_params=run_params
+        )
+        expected_fqdn_image = 'build-container-image:build-container-tag'
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[], interactive=False)
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -551,7 +564,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_commands = [
             mock.call(['docker', 'build', '-t', 'build-container-image', '-f', 'Dockerfile.build-container-image', '.']),
-            mock.call(command, fqdn_image='build-container-image', environment=[]),
+            mock.call(command, fqdn_image='build-container-image', environment=[], interactive=True),
         ]
         skipper_runner_run_mock.assert_has_calls(expected_commands)
 
@@ -568,7 +581,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_command = ['make', '-f', makefile, target]
         expected_fqdn_image = 'build-container-image:build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[])
+        skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[], interactive=True)
 
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('os.path.exists', autospec=True, return_value=True)
@@ -586,7 +599,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_command = ['make', '-f', makefile, target]
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[])
+        skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[], interactive=True)
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -602,7 +615,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_commands = [
             mock.call(['docker', 'build', '-t', 'build-container-image', '-f', 'Dockerfile.build-container-image', '.']),
-            mock.call(['make'] + make_params, fqdn_image='build-container-image', environment=[]),
+            mock.call(['make'] + make_params, fqdn_image='build-container-image', environment=[], interactive=True),
         ]
         skipper_runner_run_mock.assert_has_calls(expected_commands)
 


### PR DESCRIPTION
This should allow users to debug code that runs inside the build container (i.e. tests).
@rom-stratoscale @eran-stratoscale please review.