### PR TITLE
WIP: Connect the build container to a network.

### DIFF
--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -12,8 +12,9 @@ from skipper import utils
 @click.option('--registry', help='URL of the docker registry')
 @click.option('--build-container-image', help='Image to use as build container')
 @click.option('--build-container-tag', help='Tag of the build container')
+@click.option('--build-container-net', help='Network to connect the build container', default='host')
 @click.pass_context
-def cli(ctx, registry, build_container_image, build_container_tag, verbose):
+def cli(ctx, registry, build_container_image, build_container_tag, build_container_net, verbose):
     '''
     Easily dockerize your Git repository
     '''
@@ -23,6 +24,7 @@ def cli(ctx, registry, build_container_image, build_container_tag, verbose):
     ctx.obj['registry'] = registry
     ctx.obj['build_container_image'] = build_container_image
     ctx.obj['build_container_tag'] = build_container_tag
+    ctx.obj['build_container_net'] = build_container_net
     ctx.obj['env'] = ctx.default_map.get('env', {})
     ctx.obj['containers'] = ctx.default_map.get('containers')
 
@@ -139,10 +141,9 @@ def rmi(ctx, remote, image, tag):
 @cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.option('-i', '--interactive', help='Interactive mode', is_flag=True, default=False, envvar='SKIPPER_INTERACTIVE')
 @click.option('-e', '--env', multiple=True, help='Environment variables to pass the container')
-@click.option('-d', '--disable_net_host', help='Disable net host mode', is_flag=True, default=False)
 @click.argument('command', nargs=-1, type=click.UNPROCESSED, required=True)
 @click.pass_context
-def run(ctx, interactive, env, disable_net_host, command):
+def run(ctx, interactive, env, command):
     '''
     Run arbitrary commands
     '''
@@ -155,17 +156,16 @@ def run(ctx, interactive, env, disable_net_host, command):
                       fqdn_image=build_container,
                       environment=_expend_env(ctx, env),
                       interactive=interactive,
-                      disable_net_host=disable_net_host)
+                      net=ctx.obj['build_container_net'])
 
 
 @cli.command(context_settings=dict(ignore_unknown_options=True))
 @click.option('-i', '--interactive', help='Interactive mode', is_flag=True, default=False, envvar='SKIPPER_INTERACTIVE')
 @click.option('-e', '--env', multiple=True, help='Environment variables to pass the container')
 @click.option('-f', 'makefile', help='Makefile to use', default='Makefile')
-@click.option('-d', '--disable_net_host', help='Disable net host mode', is_flag=True, default=False)
 @click.argument('make_params', nargs=-1, type=click.UNPROCESSED, required=False)
 @click.pass_context
-def make(ctx, interactive, env, makefile, disable_net_host, make_params):
+def make(ctx, interactive, env, makefile, make_params):
     '''
     Execute makefile target(s)
     '''
@@ -179,13 +179,13 @@ def make(ctx, interactive, env, makefile, disable_net_host, make_params):
                       fqdn_image=build_container,
                       environment=_expend_env(ctx, env),
                       interactive=interactive,
-                      disable_net_host=disable_net_host)
+                      net=ctx.obj['build_container_net'])
 
 
 @cli.command()
 @click.option('-e', '--env', multiple=True, help='Environment variables to pass the container')
 @click.pass_context
-def shell(ctx, env):
+def shell(ctx, env,):
     '''
     Start a shell
     '''
@@ -194,7 +194,11 @@ def shell(ctx, env):
     build_container = _prepare_build_container(ctx.obj['registry'],
                                                ctx.obj['build_container_image'],
                                                ctx.obj['build_container_tag'])
-    return runner.run(['bash'], fqdn_image=build_container, environment=_expend_env(ctx, env), interactive=True)
+    return runner.run(['bash'],
+                      fqdn_image=build_container,
+                      environment=_expend_env(ctx, env),
+                      interactive=True,
+                      net=ctx.obj['build_container_net'])
 
 
 def _prepare_build_container(registry, image, tag):

--- a/skipper/runner.py
+++ b/skipper/runner.py
@@ -66,6 +66,7 @@ def _run_nested(fqdn_image, environment, command, interactive, net='host'):
 
 def _create_network(net):
     if not _network_exists(net):
+        logging.debug("Network %(net)s does not exist. Creating...")
         subprocess.check_output(['docker', 'network', 'create', net])
 
 

--- a/skipper/runner.py
+++ b/skipper/runner.py
@@ -21,6 +21,7 @@ def _run(cmd):
 
 
 def _run_nested(fqdn_image, environment, command, interactive, net='host'):
+    _create_network(net)
     cwd = os.getcwd()
     workspace = os.path.dirname(cwd)
     project = os.path.basename(cwd)
@@ -61,3 +62,13 @@ def _run_nested(fqdn_image, environment, command, interactive, net='host'):
     docker_cmd += [' '.join(command)]
 
     return _run(docker_cmd)
+
+
+def _create_network(net):
+    if not _network_exists(net):
+        subprocess.check_output(['docker', 'network', 'create', net])
+
+
+def _network_exists(net):
+    result = subprocess.check_output(['docker', 'network', 'ls', '-q', '-f', 'NAME=%s' % net])
+    return len(result) > 0

--- a/skipper/runner.py
+++ b/skipper/runner.py
@@ -5,9 +5,9 @@ import os
 import subprocess
 
 
-def run(command, fqdn_image=None, environment=None, interactive=False, disable_net_host=False):
+def run(command, fqdn_image=None, environment=None, interactive=False, net='host'):
     if fqdn_image is not None:
-        return _run_nested(fqdn_image, environment, command, interactive, disable_net_host)
+        return _run_nested(fqdn_image, environment, command, interactive, net)
     else:
         return _run(command)
 
@@ -20,7 +20,7 @@ def _run(cmd):
     return proc.returncode
 
 
-def _run_nested(fqdn_image, environment, command, interactive, disable_net_host=False):
+def _run_nested(fqdn_image, environment, command, interactive, net='host'):
     cwd = os.getcwd()
     workspace = os.path.dirname(cwd)
     project = os.path.basename(cwd)
@@ -32,8 +32,7 @@ def _run_nested(fqdn_image, environment, command, interactive, disable_net_host=
     docker_cmd += ['-t']
     docker_cmd += ['--rm']
 
-    if not disable_net_host:
-        docker_cmd += ['--net', 'host']
+    docker_cmd += ['--net', net]
 
     environment = environment or []
     for env in environment:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -672,7 +672,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_image_name = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_image_name, environment=[],
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('requests.get', autospec=True)
@@ -695,7 +695,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_image_name = 'registry.io:5000/build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_image_name, environment=[],
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('requests.get', autospec=True)
@@ -733,7 +733,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('os.path.exists', autospec=True, return_value=True)
@@ -752,7 +752,7 @@ class TestCLI(unittest.TestCase):
         env = ["%s=%s" % (key, value) for key, value in CONFIG_ENV_EVALUATION.iteritems()]
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=env,
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('os.path.exists', autospec=True, return_value=True)
@@ -771,7 +771,7 @@ class TestCLI(unittest.TestCase):
         env = ["%s=%s" % (key, value) for key, value in CONFIG_ENV_EVALUATION.iteritems()] + ENV
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=env,
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -786,7 +786,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_fqdn_image = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=ENV,
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -801,7 +801,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_fqdn_image = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=True, disable_net_host=False)
+                                                        interactive=True, net='host')
         del os.environ['SKIPPER_INTERACTIVE']
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
@@ -817,7 +817,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_fqdn_image = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
         del os.environ['SKIPPER_INTERACTIVE']
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
@@ -832,7 +832,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_fqdn_image = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=True, disable_net_host=False)
+                                                        interactive=True, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -847,9 +847,25 @@ class TestCLI(unittest.TestCase):
         )
         expected_commands = [
             mock.call(['docker', 'build', '-t', 'build-container-image', '-f', 'Dockerfile.build-container-image', '.']),
-            mock.call(command, fqdn_image='build-container-image', environment=[], interactive=False, disable_net_host=False),
+            mock.call(command, fqdn_image='build-container-image', environment=[], interactive=False, net='host'),
         ]
         skipper_runner_run_mock.assert_has_calls(expected_commands)
+
+    @mock.patch('subprocess.check_output', autospec=True, return_value='1234567')
+    @mock.patch('skipper.runner.run', autospec=True)
+    def test_run_with_non_default_net(self, skipper_runner_run_mock, *args):
+        global_params = self.global_params
+        global_params += ['--build-container-net', 'non-default-net']
+        command = ['ls', '-l']
+        run_params = command
+        self._invoke_cli(
+            global_params=global_params,
+            subcmd='run',
+            subcmd_params=run_params
+        )
+        expected_fqdn_image = 'build-container-image:build-container-tag'
+        skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=[],
+                                                        interactive=False, net='non-default-net')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -865,7 +881,7 @@ class TestCLI(unittest.TestCase):
         expected_command = ['make', '-f', makefile, target]
         expected_fqdn_image = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -877,7 +893,7 @@ class TestCLI(unittest.TestCase):
         expected_command = ['make', '-f', "Makefile"]
         expected_fqdn_image = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -894,7 +910,7 @@ class TestCLI(unittest.TestCase):
         expected_command = ['make', '-f', 'Makefile', '-j', '4', target, 'OS=linux']
         expected_fqdn_image = 'build-container-image:build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=False, disable_net_host=False)
+                                                        interactive=False, net='host')
 
     @mock.patch('__builtin__.open', create=True)
     @mock.patch('os.path.exists', autospec=True, return_value=True)
@@ -913,26 +929,7 @@ class TestCLI(unittest.TestCase):
         expected_command = ['make', '-f', makefile, target]
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=False, disable_net_host=False)
-
-    @mock.patch('__builtin__.open', create=True)
-    @mock.patch('os.path.exists', autospec=True, return_value=True)
-    @mock.patch('yaml.load', autospec=True, return_value=SKIPPER_CONF)
-    @mock.patch('subprocess.check_output', autospec=True, return_value='1234567\n')
-    @mock.patch('skipper.runner.run', autospec=True)
-    def test_make_net_host_disabled(self, skipper_runner_run_mock, *args):
-        makefile = 'Makefile'
-        target = 'all'
-        make_params = ['-d', '-f', makefile, target]
-        self._invoke_cli(
-            defaults=config.load_defaults(),
-            subcmd='make',
-            subcmd_params=make_params
-        )
-        expected_command = ['make', '-f', makefile, target]
-        expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(expected_command, fqdn_image=expected_fqdn_image, environment=[],
-                                                        interactive=False, disable_net_host=True)
+                                                        interactive=False, net='host')
 
     @mock.patch('subprocess.check_output', autospec=True, return_value='')
     @mock.patch('skipper.runner.run', autospec=True)
@@ -948,7 +945,7 @@ class TestCLI(unittest.TestCase):
         )
         expected_commands = [
             mock.call(['docker', 'build', '-t', 'build-container-image', '-f', 'Dockerfile.build-container-image', '.']),
-            mock.call(['make'] + make_params, fqdn_image='build-container-image', environment=[], interactive=False, disable_net_host=False),
+            mock.call(['make'] + make_params, fqdn_image='build-container-image', environment=[], interactive=False, net='host'),
         ]
         skipper_runner_run_mock.assert_has_calls(expected_commands)
 
@@ -960,7 +957,8 @@ class TestCLI(unittest.TestCase):
             subcmd='shell',
         )
         expected_fqdn_image = 'build-container-image:build-container-tag'
-        skipper_runner_run_mock.assert_called_once_with(['bash'], fqdn_image=expected_fqdn_image, environment=[], interactive=True)
+        skipper_runner_run_mock.assert_called_once_with(['bash'], fqdn_image=expected_fqdn_image, environment=[], interactive=True,
+                                                        net='host')
 
     def _invoke_cli(self, defaults=None, global_params=None, subcmd=None, subcmd_params=None):
         self.assertFalse(subcmd is None and subcmd_params is not None, 'No sub-command was provided!')

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -42,7 +42,9 @@ class TestRunner(unittest.TestCase):
     @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_simple_command_nested(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+    @mock.patch('subprocess.check_output', autospec=False)
+    def test_run_simple_command_nested_network_exist(self, check_output_mock, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+        check_output_mock.side_effect = ['d3be68b723d3\n']
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
@@ -73,7 +75,42 @@ class TestRunner(unittest.TestCase):
     @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_simple_command_nested_with_env(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+    @mock.patch('subprocess.check_output', autospec=False)
+    def test_run_simple_command_nested_network_not_exist(self, check_output_mock, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+        check_output_mock.side_effect = ['', 'new-net-hash']
+        popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
+        popen_mock.return_value.poll.return_value = -1
+        grp_getgrnam_mock.return_value.gr_gid = 978
+        os_getuid_mock.return_value = USER_ID
+        command = ['pwd']
+        runner.run(command, FQDN_IMAGE)
+        expected_nested_command = [
+            'docker', 'run',
+            '-t',
+            '--rm',
+            '--net', 'host',
+            '-e', 'SKIPPER_USERNAME=testuser',
+            '-e', 'SKIPPER_UID=%(user_uid)s' % dict(user_uid=USER_ID),
+            '-e', 'SKIPPER_DOCKER_GID=978',
+            '-v', '%(workdir)s:%(workdir)s:rw,Z' % dict(workdir=WORKDIR),
+            '-v', '/var/lib/osmosis:/var/lib/osmosis:rw,Z',
+            '-v', '/var/run/docker.sock:/var/run/docker.sock:Z',
+            '-v', '/opt/skipper/skipper-entrypoint.sh:/opt/skipper/skipper-entrypoint.sh:Z',
+            '-w', PROJECT_DIR,
+            '--entrypoint', '/opt/skipper/skipper-entrypoint.sh',
+            FQDN_IMAGE,
+            command[0]
+        ]
+        popen_mock.assert_called_once_with(expected_nested_command)
+
+    @mock.patch('getpass.getuser', autospec=True, return_value='testuser')
+    @mock.patch('os.getcwd', autospec=True, return_value=PROJECT_DIR)
+    @mock.patch('os.getuid', autospec=True)
+    @mock.patch('grp.getgrnam', autospec=True)
+    @mock.patch('subprocess.Popen', autospec=False)
+    @mock.patch('subprocess.check_output', autospec=False)
+    def test_run_simple_command_nested_with_env(self, check_output_mock, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+        check_output_mock.side_effect = ['d3be68b723d3\n']
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
@@ -106,7 +143,9 @@ class TestRunner(unittest.TestCase):
     @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_simple_command_nested_interactive(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+    @mock.patch('subprocess.check_output', autospec=False)
+    def test_run_simple_command_nested_interactive(self, check_output_mock, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+        check_output_mock.side_effect = ['d3be68b723d3\n']
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
@@ -138,7 +177,9 @@ class TestRunner(unittest.TestCase):
     @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True,)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_complex_command_nested(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+    @mock.patch('subprocess.check_output', autospec=False)
+    def test_run_complex_command_nested(self, check_output_mock, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+        check_output_mock.side_effect = ['d3be68b723d3\n']
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978
@@ -169,7 +210,9 @@ class TestRunner(unittest.TestCase):
     @mock.patch('os.getuid', autospec=True)
     @mock.patch('grp.getgrnam', autospec=True)
     @mock.patch('subprocess.Popen', autospec=False)
-    def test_run_complex_command_nested_with_env(self, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+    @mock.patch('subprocess.check_output', autospec=False)
+    def test_run_complex_command_nested_with_env(self, check_output_mock, popen_mock, grp_getgrnam_mock, os_getuid_mock, *args):
+        check_output_mock.side_effect = ['d3be68b723d3\n']
         popen_mock.return_value.stdout.readline.side_effect = ['aaa', 'bbb', 'ccc', '']
         popen_mock.return_value.poll.return_value = -1
         grp_getgrnam_mock.return_value.gr_gid = 978


### PR DESCRIPTION
by default skipper will run the build container with net=host. this can be overridden with other network.
note: the creation of the network is still missing.
