### PR TITLE
Added container-context flag to build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can also build mutliple images with single command:
 skipper build development service2
 ```
 
-A context path can be added to the build command, The build’s context is the files at a specified location PATH:
+A context path can be added to the build command, The build’s context is the files at a specified location PATH, the default is current directory:
 ```bash
 skipper buid service1 --container-context /path/to/context/dir
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ You can also build mutliple images with single command:
 skipper build development service2
 ```
 
+A context path can be added to the build command, The build’s context is the files at a specified location PATH:
+```bash
+skipper buid service1 --container-context /path/to/context/dir
+```
+
 If no image is specifed skipper will build all detected images:
 ```bash
 skipper build
@@ -133,6 +138,7 @@ Skipper allows you to define commonly used parameters in a configuration file `s
 registry: some-registry 
 build-container-image: development
 build-container-tag: latest
+container-context: /path/to/context/dir
 
 make: 
     makefile: Makefile.arm32

--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -32,6 +32,7 @@ def cli(ctx, registry, build_container_image, build_container_tag, build_contain
     ctx.obj['containers'] = ctx.default_map.get('containers')
     ctx.obj['volumes'] = ctx.default_map.get('volumes')
     ctx.obj['workdir'] = ctx.default_map.get('workdir')
+    ctx.obj['container_context'] = ctx.default_map.get('container_context')
 
 
 @cli.command()
@@ -66,7 +67,10 @@ def build(ctx, images_to_build, container_context):
 
         fqdn_image = image + ':' + tag
         if not container_context:
-            container_context = os.path.dirname(dockerfile)
+            if ctx.obj['container_context']:
+                container_context = ctx.obj['container_context']
+            else:
+                container_context = os.path.dirname(dockerfile)
         command = ['docker', 'build', '-f', dockerfile, '-t', fqdn_image, container_context]
         ret = runner.run(command)
 

--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -36,8 +36,9 @@ def cli(ctx, registry, build_container_image, build_container_tag, build_contain
 
 @cli.command()
 @click.argument('images_to_build', nargs=-1, metavar='[IMAGE...]')
+@click.option('--container-context', help='Container context path', default=None)
 @click.pass_context
-def build(ctx, images_to_build):
+def build(ctx, images_to_build, container_context):
     '''
     Build a container
     '''
@@ -64,8 +65,9 @@ def build(ctx, images_to_build):
             continue
 
         fqdn_image = image + ':' + tag
-        path = os.path.dirname(dockerfile)
-        command = ['docker', 'build', '-f', dockerfile, '-t', fqdn_image, path]
+        if not container_context:
+            container_context = os.path.dirname(dockerfile)
+        command = ['docker', 'build', '-f', dockerfile, '-t', fqdn_image, container_context]
         ret = runner.run(command)
 
         if ret != 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -168,6 +168,29 @@ class TestCLI(unittest.TestCase):
         ]
         skipper_runner_run_mock.assert_called_once_with(expected_command)
 
+    @mock.patch('skipper.utils.get_images_from_dockerfiles', autospec=True,
+                return_value={'image1': '/home/user/work/project/Dockerfile.image1'})
+    @mock.patch('skipper.git.get_hash', autospec=True, return_value='1234567')
+    @mock.patch('os.path.exists', autospec=True, return_value=True)
+    @mock.patch('skipper.runner.run', autospec=True, return_value=0)
+    def test_build_existing_image_with_context(self, skipper_runner_run_mock, *args):
+        build_params = ['image1',
+                        '--container-context',
+                        '/home/user/work']
+        self._invoke_cli(
+            global_params=self.global_params,
+            subcmd='build',
+            subcmd_params=build_params
+        )
+        expected_command = [
+            'docker',
+            'build',
+            '-f', '/home/user/work/project/Dockerfile.image1',
+            '-t', 'image1:1234567',
+            '/home/user/work'
+        ]
+        skipper_runner_run_mock.assert_called_once_with(expected_command)
+
     @mock.patch('skipper.git.get_hash', autospec=True, return_value='1234567')
     @mock.patch('os.path.exists', autospec=True, return_value=False)
     @mock.patch('skipper.runner.run', autospec=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -176,7 +176,7 @@ class TestCLI(unittest.TestCase):
     def test_build_existing_image_with_context(self, skipper_runner_run_mock, *args):
         build_params = ['image1',
                         '--container-context',
-                        '/home/user/work']
+                        '/home/user/work/project']
         self._invoke_cli(
             global_params=self.global_params,
             subcmd='build',
@@ -187,7 +187,7 @@ class TestCLI(unittest.TestCase):
             'build',
             '-f', '/home/user/work/project/Dockerfile.image1',
             '-t', 'image1:1234567',
-            '/home/user/work'
+            '/home/user/work/project'
         ]
         skipper_runner_run_mock.assert_called_once_with(expected_command)
 


### PR DESCRIPTION
The flag is optional and by default it will take the path of the dockerfile.

skipper build --help
Usage: skipper build [OPTIONS] [IMAGE...]

  Build a container

Options:
  --container-context TEXT  Container context path
  --help                    Show this message and exit.
