### PR TITLE
fix build context loop bug

### DIFF
--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -66,12 +66,13 @@ def build(ctx, images_to_build, container_context):
             continue
 
         fqdn_image = image + ':' + tag
-        if not container_context:
-            if ctx.obj['container_context']:
-                container_context = ctx.obj['container_context']
-            else:
-                container_context = os.path.dirname(dockerfile)
-        command = ['docker', 'build', '-f', dockerfile, '-t', fqdn_image, container_context]
+        if container_context is not None:
+            build_context = container_context
+        elif ctx.obj['container_context']:
+            build_context = ctx.obj['container_context']
+        else:
+            build_context = os.path.dirname(dockerfile)
+        command = ['docker', 'build', '-f', dockerfile, '-t', fqdn_image, build_context]
         ret = runner.run(command)
 
         if ret != 0:


### PR DESCRIPTION
if container_context is none and it get a value in the first iteration it will be used in the next one as well.