### PR TITLE
setup.py use setuptools instead of distutils.core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 import os
 import sys
 from setuptools import find_packages
-from distutils.core import setup
 
 # Workaround: bdist_wheel doesn't support absolute paths in data_files
 # (see: https://bitbucket.org/pypa/wheel/issues/92). 
 if os.getuid() == 0 and 'bdist_wheel' in sys.argv:
     raise RuntimeError("This setup.py does not support wheels")
 
-setup(
+setuptools.setup(
     setup_requires=[
         'pbr >= 1.9',
         'setuptools >= 17.1'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from setuptools import find_packages
+import setuptools 
 
 # Workaround: bdist_wheel doesn't support absolute paths in data_files
 # (see: https://bitbucket.org/pypa/wheel/issues/92). 


### PR DESCRIPTION
When setuptools installs all dependencies as part of the package installation
while distutils silently fails the installation