### PR TITLE
Upgrade skipper click version to latest major

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML>=3.11
-click==6.7
+click==8.0
 requests>=2.6.0
 tabulate>=0.7.5
 six>=1.10.0


### PR DESCRIPTION
Since skipper is useful to be installed as a system-level
package and not just in a virtualenv, the older click version
conflicts with other utilities that use newer version of
click (such as Black)

This upgrade should fix that conflict. The breaking changes
between 6.0 -> 7.0 were changing underscores to dashes by
default. Skipper doesn't have any underscores in its subcommands

The breaking changes between 7.0 and 8.0 seem to be just dropping
support for Python 3.5 and Python 2.7

So I think this upgrade should be rather seamless