### PR TITLE
Fixed shell interpulation TypeError

### DIFF
--- a/skipper/config.py
+++ b/skipper/config.py
@@ -36,7 +36,7 @@ def _normalize_config(config, normalized_config):
 
 def _interpolate_env_vars(key):
     for match in findall(r'\$\(.+\)', key):
-        output = check_output("echo " + match, shell=True).strip()
+        output = check_output("echo " + match, shell=True).strip().decode("utf-8")
         if not output:
             raise ValueError(match)
         key = key.replace(match, output)


### PR DESCRIPTION
check_output returns a byte string and we need a character (Unicode) string for replace to work