### PR TITLE
Handle host path directory creation failure differently for podman

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -333,7 +333,7 @@ max-locals=15
 max-returns=6
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=13
 
 # Maximum number of statements in function / method body
 max-statements=50


### PR DESCRIPTION
# Some background

* `-v x:y` volume mounts where `x` is a host path that doesn't exist are a hard error on Podman
* `-v x:y` volume mounts where `x` is a host path that doesn't exist cause `x` to be created on the
  host with root permissions on Docker
* skipper avoids the annoying root permissions by creating `x` in
  advance with its own permissions, thus preventing docker from creating
  the directory
* skipper doesn't try too hard to do the above bullet, it just gives up
  if it doesn't have permissions to create that directory
* on docker, giving up is fine - docker will simply create the
  directory, and it will have root permissions, not that big of a deal
* on podman, giving up is bad - it means the directory doesn't get
  created and since for podman missing `x` is a hard error, running
  podman will fail and so non of the skipper commands work

# Solution

Simply ignore volume mounts where `x` doesn't exist and also `x` cannot
be created by skipper when the runtime is Podman, and emit a warning
saying that this was implicitly done. This will avoid Podman from
crashing.