### PR TITLE
README: escape dollars to avoid math rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ For example, suppose the shell contains EXTERNAL_PORT=5000 and you supply this c
 env:
     EXTERNAL_PORT: $EXTERNAL_PORT
 ````
-When you run Skipper command with this configuration, Skipper looks for the EXTERNAL_PORT environment variable in the shell and substitutes its value in.In this example, Skipper resolves the $EXTERNAL_PORT to "5000" and will set EXTERNAL_PORT=5000 environment in the container.
+When you run Skipper command with this configuration, Skipper looks for the EXTERNAL_PORT environment variable in the shell and substitutes its value in.In this example, Skipper resolves the `$EXTERNAL_PORT` to "5000" and will set EXTERNAL_PORT=5000 environment in the container.
 
 If an environment variable is not set, Skipper substitutes with an empty string.
 
-Both $VARIABLE and ${VARIABLE} syntax are supported. Extended shell-style features, such as ${VARIABLE-default} and ${VARIABLE/foo/bar}, are not supported.
+Both `$VARIABLE` and `${VARIABLE}` syntax are supported. Extended shell-style features, such as `${VARIABLE-default}` and `${VARIABLE/foo/bar}`, are not supported.
 
-You can use a $$ (double-dollar sign) when your configuration needs a literal dollar sign. This also prevents Skipper from interpolating a value, so a $$ allows you to refer to environment variables that you don’t want processed by Skipper.
+You can use a `$$` (double-dollar sign) when your configuration needs a literal dollar sign. This also prevents Skipper from interpolating a value, so a `$$` allows you to refer to environment variables that you don’t want processed by Skipper.
 ````
 env:
     VAR: $$VAR_NOT_INTERPOLATED

--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ env:
 ````
 
 ### Shell Interpolation
-
 Skipper supports evaluating shell commands inside its configuration file using `$(command)` notation.
 e.g.
 


### PR DESCRIPTION
GitHub markdown renders `$TeX math$` [since mid-2022](https://github.blog/2022-05-19-math-support-in-markdown/), which currently messes up the passage about $VARIABLE syntaxes on the rendered README:
![Screenshot from 2023-02-13 13-32-42](https://user-images.githubusercontent.com/273688/218448101-7b072208-1375-40f1-a5ec-5dd61370cdbd.png)

I escaped everything containing `$` with backticks.
Preview: https://github.com/Stratoscale/skipper/blob/21b2edeead7381f4bfe7aa1c8797b9afbceb6647/README.md#variable-substitution