### PR TITLE
Support wheels distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,4 @@
-import os
-import sys
 from setuptools import setup
-
-# Workaround: bdist_wheel doesn't support absolute paths in data_files
-# (see: https://bitbucket.org/pypa/wheel/issues/92). 
-if os.getuid() == 0 and 'bdist_wheel' in sys.argv:
-    raise RuntimeError("This setup.py does not support wheels")
 
 setup(
     setup_requires=[


### PR DESCRIPTION
Seems like the comment about data files not being included in wheels when using full paths is no longer true.

The check I've done is making sure the completion output still works when installing the wheel files, which seems to work.

In addition, it produces warnings that the legacy installation method will get deprecated soon:
```
DEPRECATION: strato-skipper was installed using the legacy 'setup.py
install' method, because a wheel could not be built for it. pip 23.1
will enforce this behaviour change.
```