### PR TITLE
Remove support (and tests) for Python 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,5 +74,5 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
     - name: Test usage
       run: |
-        skipper make clean
+        sudo skipper make clean
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.x']
+        python-version: [ '3.x']
     steps:
     - name: Check out code
       uses: actions/checkout@v1
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.x']
+        python-version: [ '3.x']
     steps:
     - name: Check out code
       uses: actions/checkout@v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v1
-    - name: Set up Python 2.7
+    - name: Set up Python 3
       uses: actions/setup-python@v1
       with:
-        python-version: 2.7.18
+        python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,16 +34,6 @@ unsafe-load-any-extension=no
 # run arbitrary code
 extension-pkg-whitelist=
 
-# Allow optimization of some AST trees. This will activate a peephole AST
-# optimizer, which will apply various small optimizations. For instance, it can
-# be used to obtain the result of joining multiple strings with the addition
-# operator. Joining a lot of strings can lead to a maximum recursion error in
-# Pylint and this flag can prevent that. It has one side effect, the resulting
-# AST will be different than the one from reality. This option is deprecated
-# and it will be removed in Pylint 2.0.
-optimize-ast=no
-
-
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
@@ -65,7 +55,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating,missing-docstring,fixme,superfluous-parens,too-many-locals
+disable=useless-suppression,suppressed-message,missing-docstring,fixme,superfluous-parens,too-many-locals,unspecified-encoding,missing-timeout
 
 
 [REPORTS]
@@ -74,12 +64,6 @@ disable=import-star-module-level,old-octal-literal,oct-method,print-statement,un
 # (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=text
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]". This option is deprecated
-# and it will be removed in Pylint 2.0.
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=no
@@ -141,62 +125,32 @@ property-classes=abc.abstractproperty
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,30}$
 
-# Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct variable names
 variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-z0-9_]{2,30}$
 
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
@@ -224,12 +178,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 max-module-lines=1000
@@ -404,4 +352,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/Dockerfile.skipper-build
+++ b/Dockerfile.skipper-build
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.11
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 requires-dist = setuptools
+requires-python = >=3
 
 
 [files]

--- a/skipper/git.py
+++ b/skipper/git.py
@@ -16,7 +16,7 @@ def get_hash(short=False):
     if uncommitted_changes():
         logging.warning("*** Uncommitted changes present - Build container version might be outdated ***")
 
-    return subprocess.check_output(git_command).decode().strip()
+    return subprocess.check_output(git_command).strip()
 
 
 def uncommitted_changes():

--- a/skipper/utils.py
+++ b/skipper/utils.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import subprocess
-import shutil
+from shutil import which
 from six.moves import http_client
 import requests
 from requests_bearer import HttpBearerAuth
@@ -151,7 +151,7 @@ def dockerfile_to_image(dockerfile):
 
 def is_tool(name):
     """Check whether `name` is on PATH and marked as executable."""
-    return shutil.which(name) is not None
+    return which(name) is not None
 
 
 def get_runtime_command():
@@ -173,7 +173,7 @@ def get_extra_file(filename):
 def run_container_command(args):
     cmd = [get_runtime_command()]
     cmd.extend(args)
-    return str(subprocess.check_output(cmd).decode().strip())
+    return str(subprocess.check_output(cmd).strip())
 
 
 def create_path_and_add_data(full_path, data, is_file):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,9 @@ from six.moves import http_client
 import click
 import six
 from click import testing
+from shutil import which
+from requests import HTTPError
+
 from skipper import cli
 from skipper import config, utils
 
@@ -295,7 +298,7 @@ class TestCLI(unittest.TestCase):
                                                                             return_value={
                                                                                 'image1': '/home/user/work/project/Dockerfile.image1',
                                                                                 'image2': '/home/user/work/project/Dockerfile.image2'}))
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_CONTEXT))
     @mock.patch('skipper.git.get_hash', mock.MagicMock(autospec=True, return_value='1234567'))
@@ -317,7 +320,7 @@ class TestCLI(unittest.TestCase):
         ]
         skipper_runner_run_mock.assert_called_once_with(expected_command)
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_CONTEXT_NO_TAG))
     @mock.patch('skipper.git.get_hash', mock.MagicMock(autospec=True, return_value='1234567'))
@@ -461,7 +464,7 @@ class TestCLI(unittest.TestCase):
                                                                             return_value={
                                                                                 'image1': '/home/user/work/project/Dockerfile.image1',
                                                                                 'image2': '/home/user/work/project/Dockerfile.image2'}))
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF))
     @mock.patch('skipper.git.get_hash', mock.MagicMock(autospec=True, return_value='1234567'))
@@ -482,7 +485,7 @@ class TestCLI(unittest.TestCase):
         ]
         skipper_runner_run_mock.assert_called_once_with(expected_command)
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.abspath',
                 mock.MagicMock(autospec=True, return_value='/home/user/work/project/app1/Dockerfile'))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
@@ -677,7 +680,7 @@ class TestCLI(unittest.TestCase):
         ]
         skipper_runner_run_mock.assert_has_calls(expected_commands)
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF))
     @mock.patch('skipper.git.get_hash', mock.MagicMock(autospec=True, return_value='1234567'))
@@ -1039,7 +1042,7 @@ class TestCLI(unittest.TestCase):
     @mock.patch('requests.get', autospec=True)
     def test_rmi_remote_fail(self, requests_get_mock, requests_delete_mock, requests_bearer_auth_mock):
         requests_get_mock.side_effect = [mock.Mock(headers={'Docker-Content-Digest': 'digest'})]
-        requests_delete_mock.side_effect = [mock.Mock(ok=False)]
+        requests_delete_mock.side_effect = HTTPError()
         result = self._invoke_cli(
             global_params=self.global_params,
             subcmd='rmi',
@@ -1130,7 +1133,7 @@ class TestCLI(unittest.TestCase):
         )
         self.assertIsInstance(ret.exception, click.exceptions.ClickException)
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1150,7 +1153,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, workspace=None, use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_ENV))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1172,7 +1175,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, workspace=None, use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists',
                 mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(
@@ -1203,7 +1206,7 @@ class TestCLI(unittest.TestCase):
                                                         use_cache=False,
                                                         env_file=(ENV_FILE_PATH,))
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists',
                 mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(
@@ -1234,7 +1237,7 @@ class TestCLI(unittest.TestCase):
                                                         use_cache=False,
                                                         env_file=tuple(ENV_FILES))
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_ENV))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1256,7 +1259,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, workspace=None, use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('os.environ', {})
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_ENV_LIST))
@@ -1279,7 +1282,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, workspace=None, use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('os.environ', {'key2': 'value2'})
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_ENV_LIST))
@@ -1302,7 +1305,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, workspace=None, use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_ENV_WRONG_TYPE))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1582,7 +1585,7 @@ class TestCLI(unittest.TestCase):
         self.assertEqual("Invalid port number: port 121111111 is out of range", result.exception.message)
         self.assertEqual(-1, result.exit_code)
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_VOLUMES))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1601,7 +1604,7 @@ class TestCLI(unittest.TestCase):
                                                         volumes=['volume1', 'volume2'], workspace=None,
                                                         workdir=None, use_cache=False, env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_SHELL_INTERPOLATION))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1617,7 +1620,7 @@ class TestCLI(unittest.TestCase):
         expected_fqdn_image = 'skipper-conf-build-container-image:skipper-conf-build-container-tag'
         skipper_runner_run_mock.assert_called_once_with(command, fqdn_image=expected_fqdn_image, environment=['KEY=10'],
                                                         interactive=False, name=None, net=None, publish=(),
-                                                        volumes=['/bin/cat:/cat'], workspace=None,
+                                                        volumes=[f'{which("cat")}:/cat'], workspace=None,
                                                         workdir=None, use_cache=False, env_file=())
 
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_INVALID_SHELL_INTERPOLATION))
@@ -1632,7 +1635,7 @@ class TestCLI(unittest.TestCase):
                 subcmd_params=run_params
             )
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_WORKDIR))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1652,7 +1655,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir='test-workdir', workspace=None, use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_WORKSPACE))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1672,7 +1675,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, workspace="/test/workspace", use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_GIT_REV))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1693,7 +1696,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, use_cache=False, workspace=None,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_GIT_REV))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
@@ -1769,7 +1772,7 @@ class TestCLI(unittest.TestCase):
                                                         workdir=None, workspace=None, use_cache=False,
                                                         env_file=())
 
-    @mock.patch('__builtin__.open', mock.MagicMock(create=True))
+    @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF))
     @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from skipper import utils
 
 class TestUtils(unittest.TestCase):
 
-    @mock.patch('skipper.utils.find_executable', autospec=False)
+    @mock.patch('skipper.utils.which', autospec=False)
     def test_get_runtime_command(self, find_executable_mock):
         utils.CONTAINER_RUNTIME_COMMAND = None
         find_executable_mock.side_effect = "done"


### PR DESCRIPTION
Checks are no longer working for Python 2 (saying ``Version 2.x with arch x64 not found``) and we no longer required to support such an old version.

This removes the tests and also requires at least Python 3.0.0 when doing the installation.