### PR TITLE
fix tag format as utf-8 instead of byte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vscode
+**__pycache__**
+**.pytest_cache**
 *.egg-info
 *.pyc
 .cache

--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -106,7 +106,7 @@ def build(ctx, images_to_build, container_context, cache):
                 continue
             valid_images_to_build[image] = valid_images[image]
 
-    tag = git.get_hash()
+    tag = git.get_hash().decode('utf-8')
     for image, dockerfile in six.iteritems(valid_images_to_build):
         utils.logger.info('Building image: %s', image)
 

--- a/skipper/cli.py
+++ b/skipper/cli.py
@@ -106,7 +106,7 @@ def build(ctx, images_to_build, container_context, cache):
                 continue
             valid_images_to_build[image] = valid_images[image]
 
-    tag = git.get_hash().decode('utf-8')
+    tag = git.get_hash()
     for image, dockerfile in six.iteritems(valid_images_to_build):
         utils.logger.info('Building image: %s', image)
 

--- a/skipper/git.py
+++ b/skipper/git.py
@@ -18,6 +18,7 @@ def get_hash(short=False):
 
     return subprocess.check_output(git_command).strip().decode('utf-8')
 
+
 def uncommitted_changes():
     """Return True is there are uncommitted changes."""
     return subprocess.call(['git', 'diff', '--quiet', 'HEAD']) != 0

--- a/skipper/git.py
+++ b/skipper/git.py
@@ -16,8 +16,7 @@ def get_hash(short=False):
     if uncommitted_changes():
         logging.warning("*** Uncommitted changes present - Build container version might be outdated ***")
 
-    return subprocess.check_output(git_command).strip()
-
+    return subprocess.check_output(git_command).strip().decode('utf-8')
 
 def uncommitted_changes():
     """Return True is there are uncommitted changes."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1680,7 +1680,7 @@ class TestCLI(unittest.TestCase):
     @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_GIT_REV))
-    @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
+    @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value=b'1234567\n'))
     @mock.patch('skipper.git.uncommitted_changes', mock.MagicMock(return_value=True))
     @mock.patch('skipper.runner.run', autospec=True)
     def test_run_with_config_including_git_revision_with_uncommitted_changes(self, skipper_runner_run_mock):
@@ -1701,7 +1701,7 @@ class TestCLI(unittest.TestCase):
     @mock.patch('builtins.open', mock.MagicMock(create=True))
     @mock.patch('os.path.exists', mock.MagicMock(autospec=True, return_value=True))
     @mock.patch('yaml.safe_load', mock.MagicMock(autospec=True, return_value=SKIPPER_CONF_WITH_GIT_REV))
-    @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value='1234567\n'))
+    @mock.patch('subprocess.check_output', mock.MagicMock(autospec=True, return_value=b'1234567\n'))
     @mock.patch('skipper.git.uncommitted_changes', mock.MagicMock(return_value=False))
     @mock.patch('skipper.runner.run', autospec=True)
     def test_run_with_config_including_git_revision_without_uncommitted_changes(self, skipper_runner_run_mock):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3,8 +3,8 @@ import mock
 from skipper import git
 
 
-GIT_HASH_FULL = '00efe974e3cf18c3493f110f5aeda04ff78b125f'
-GIT_HASH_SHORT = '00efe97'
+GIT_HASH_FULL = b'00efe974e3cf18c3493f110f5aeda04ff78b125f'
+GIT_HASH_SHORT = b'00efe97'
 
 
 class TestGit(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestGit(unittest.TestCase):
         git_hash = git.get_hash()
         exists_mock.assert_called_once_with('.git')
         check_output_mock.assert_called_once_with(['git', 'rev-parse', 'HEAD'])
-        self.assertEqual(git_hash, GIT_HASH_FULL)
+        self.assertEqual(git_hash, GIT_HASH_FULL.decode('utf-8'))
 
     @mock.patch('subprocess.check_output', return_value=GIT_HASH_FULL)
     @mock.patch('os.path.exists', return_value=True)
@@ -22,7 +22,7 @@ class TestGit(unittest.TestCase):
         git_hash = git.get_hash(short=False)
         exists_mock.assert_called_once_with('.git')
         check_output_mock.assert_called_once_with(['git', 'rev-parse', 'HEAD'])
-        self.assertEqual(git_hash, GIT_HASH_FULL)
+        self.assertEqual(git_hash, GIT_HASH_FULL.decode('utf-8'))
 
     @mock.patch('subprocess.check_output', return_value=GIT_HASH_SHORT)
     @mock.patch('os.path.exists', return_value=True)
@@ -30,7 +30,7 @@ class TestGit(unittest.TestCase):
         git_hash = git.get_hash(short=True)
         exists_mock.assert_called_once_with('.git')
         check_output_mock.assert_called_once_with(['git', 'rev-parse', '--short', 'HEAD'])
-        self.assertEqual(git_hash, GIT_HASH_SHORT)
+        self.assertEqual(git_hash, GIT_HASH_SHORT.decode('utf-8'))
 
     @mock.patch('subprocess.check_output')
     @mock.patch('os.path.exists', return_value=False)


### PR DESCRIPTION
`git.get_hash()` return's bytes instead of string 
https://github.com/Stratoscale/skipper/blob/upstream/skipper/git.py#L19

fix #163 